### PR TITLE
DBのテーブル修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@
 # shipping_originsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|origin_region|integer|null: false|
-|shipping_day|integer|null: false|
-|shipping_method|integer|null: false|
-|shipping_burden|boolean|null: false|
+|prefecture_id|integer|null: false|
+|days_id|integer|null: false|
+|method_id|integer|null: false|
+|burden_id|integer|null: false|
 |item_id|references|null: false, foreign_key: true|
 ## Association
 - belongs_to :item

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |zip_code|string|length: { maximum: 8 }|
-|prefecture|string||
+|prefecture_id|integer||
 |city|string||
 |street_number|string||
 |building|string||
@@ -44,7 +44,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |zip_code|string|null: false, length: { maximum: 8 }|
-|prefecture|string|null: false|
+|prefecture_id|integer|null: false|
 |city|string|null: false|
 |street_number|string|null: false|
 |building|string||
@@ -140,7 +140,7 @@
 |------|----|-------|
 |name|string|null: false|
 |parent_id|string|null: false|
-|item_id|string|null: false|
+|item_id|references|null: false, foreign_key: true|
 ## Association
 - belongs_to :item
 - belongs_to :parent, class_name: :Category

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@
 |Column|Type|Options|
 |------|----|-------|
 |nickname|string|null: false, length: { maximum: 20 }|
-|introduction|text||
-|birthday|date||
-|family_name|string|null: false|
-|first_name|string|null: false|
-|family_name_kana|string|null: false|
-|first_name_kana|string|null: false|
+|introduction|text|length: { maximum: 1000 }|
+|birthday|date|null: false|
+|family_name|string|null: false ,length: { maximum: 35 }|
+|first_name|string|null: false, length: { maximum: 35 }|
+|family_name_kana|string|null: false, length: { maximum: 35 }|
+|first_name_kana|string|null: false, length: { maximum: 35 }|
 |user_id|references|null: false, foreign_key: true|
 ## Association
 - belongs_to :user
@@ -33,9 +33,9 @@
 |------|----|-------|
 |zip_code|string|length: { maximum: 8 }|
 |prefecture_id|integer||
-|city|string||
-|street_number|string||
-|building|string||
+|city|string|length: { maximum: 50 }|
+|street_number|string|length: { maximum: 100 }|
+|building|string|length: { maximum: 100 }|
 |user_id|references|null: false, foreign_key: true|
 ## Association
 - belongs_to :user
@@ -45,9 +45,9 @@
 |------|----|-------|
 |zip_code|string|null: false, length: { maximum: 8 }|
 |prefecture_id|integer|null: false|
-|city|string|null: false|
-|street_number|string|null: false|
-|building|string||
+|city|string|null: false, length: { maximum: 50 }|
+|street_number|string|null: false, length: { maximum: 100 }|
+|building|string|length: { maximum: 100 }|
 |telephone|string||
 |user_id|references|null: false, foreign_key: true|
 ## Association

--- a/README.md
+++ b/README.md
@@ -125,12 +125,12 @@
 - belongs_to :deal
 - belongs_to :user
 
-# item_detailテーブル
+# item_detailsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|size|integer|null: false|
+|size_id|integer||
 |brand|string||
-|condition|integer|null: false|
+|condition_id|integer|null: false|
 |item_id|references|null: false, foreign_key: true|
 ## Association
 - belongs_to :item

--- a/db/migrate/20190707073046_remove_columns_from_shipping_origins.rb
+++ b/db/migrate/20190707073046_remove_columns_from_shipping_origins.rb
@@ -1,0 +1,8 @@
+class RemoveColumnsFromShippingOrigins < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :shipping_origins, :origin_region, :integer
+    remove_column :shipping_origins, :shipping_day, :integer
+    remove_column :shipping_origins, :shipping_method, :integer
+    remove_column :shipping_origins, :shipping_burden, :boolean
+  end
+end

--- a/db/migrate/20190707073534_add_columns_to_shipping_origins.rb
+++ b/db/migrate/20190707073534_add_columns_to_shipping_origins.rb
@@ -1,0 +1,8 @@
+class AddColumnsToShippingOrigins < ActiveRecord::Migration[5.2]
+  def change
+    add_column :shipping_origins, :prefecture_id, :integer, null: false
+    add_column :shipping_origins, :shipping_day_id, :integer, null: false
+    add_column :shipping_origins, :shipping_method_id, :integer, null: false
+    add_column :shipping_origins, :shipping_burden_id, :integer, null: false
+  end
+end

--- a/db/migrate/20190707073534_add_columns_to_shipping_origins.rb
+++ b/db/migrate/20190707073534_add_columns_to_shipping_origins.rb
@@ -1,8 +1,8 @@
 class AddColumnsToShippingOrigins < ActiveRecord::Migration[5.2]
   def change
     add_column :shipping_origins, :prefecture_id, :integer, null: false
-    add_column :shipping_origins, :shipping_day_id, :integer, null: false
-    add_column :shipping_origins, :shipping_method_id, :integer, null: false
-    add_column :shipping_origins, :shipping_burden_id, :integer, null: false
+    add_column :shipping_origins, :days_id, :integer, null: false
+    add_column :shipping_origins, :method_id, :integer, null: false
+    add_column :shipping_origins, :burden_id, :integer, null: false
   end
 end

--- a/db/migrate/20190707074503_remove_columns_from_item_details.rb
+++ b/db/migrate/20190707074503_remove_columns_from_item_details.rb
@@ -1,0 +1,6 @@
+class RemoveColumnsFromItemDetails < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :item_details, :size, :integer
+    remove_column :item_details, :condition, :integer
+  end
+end

--- a/db/migrate/20190707074642_add_columns_to_item_details.rb
+++ b/db/migrate/20190707074642_add_columns_to_item_details.rb
@@ -1,0 +1,6 @@
+class AddColumnsToItemDetails < ActiveRecord::Migration[5.2]
+  def change
+    add_column :item_details, :size_id, :integer
+    add_column :item_details, :condition_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_07_074642) do
+ActiveRecord::Schema.define(version: 2019_07_06_035100) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -66,8 +66,8 @@ ActiveRecord::Schema.define(version: 2019_07_07_074642) do
     t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "size_id"
-    t.integer "condition_id", null: false
+    t.integer "condition"
+    t.integer "size"
     t.index ["item_id"], name: "index_item_details_on_item_id"
   end
 
@@ -125,10 +125,10 @@ ActiveRecord::Schema.define(version: 2019_07_07_074642) do
     t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "prefecture_id", null: false
-    t.integer "shipping_day_id", null: false
-    t.integer "shipping_method_id", null: false
-    t.integer "shipping_burden_id", null: false
+    t.boolean "shipping_burden"
+    t.integer "shipping_method"
+    t.integer "shipping_day"
+    t.integer "origin_region"
     t.index ["item_id"], name: "index_shipping_origins_on_item_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_06_035100) do
+ActiveRecord::Schema.define(version: 2019_07_07_074642) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -62,12 +62,12 @@ ActiveRecord::Schema.define(version: 2019_07_06_035100) do
   end
 
   create_table "item_details", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "size", null: false
     t.string "brand"
-    t.integer "condition", null: false
     t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "size_id"
+    t.integer "condition_id", null: false
     t.index ["item_id"], name: "index_item_details_on_item_id"
   end
 
@@ -122,13 +122,13 @@ ActiveRecord::Schema.define(version: 2019_07_06_035100) do
   end
 
   create_table "shipping_origins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "origin_region", null: false
-    t.integer "shipping_day", null: false
-    t.integer "shipping_method", null: false
-    t.boolean "shipping_burden", null: false
     t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "prefecture_id", null: false
+    t.integer "shipping_day_id", null: false
+    t.integer "shipping_method_id", null: false
+    t.integer "shipping_burden_id", null: false
     t.index ["item_id"], name: "index_shipping_origins_on_item_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_06_035100) do
+ActiveRecord::Schema.define(version: 2019_07_07_074642) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -66,8 +66,8 @@ ActiveRecord::Schema.define(version: 2019_07_06_035100) do
     t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "condition"
-    t.integer "size"
+    t.integer "size_id"
+    t.integer "condition_id", null: false
     t.index ["item_id"], name: "index_item_details_on_item_id"
   end
 
@@ -125,10 +125,10 @@ ActiveRecord::Schema.define(version: 2019_07_06_035100) do
     t.bigint "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "shipping_burden"
-    t.integer "shipping_method"
-    t.integer "shipping_day"
-    t.integer "origin_region"
+    t.integer "prefecture_id", null: false
+    t.integer "days_id", null: false
+    t.integer "method_id", null: false
+    t.integer "burden_id", null: false
     t.index ["item_id"], name: "index_shipping_origins_on_item_id"
   end
 


### PR DESCRIPTION
# WHAT
渡瀬さん
shipping_originsテーブル、item_detailsテーブルのカラムを変更する　

加藤
渡瀬さんのマイグレーションファイルの確認と、文字数の長さ制限の設定がちゃんとできていなかったので、設定する。テストを書く際の参考にしてください。

# WHY
商品の詳細を表示するのに必要であるため

# ER図
![データベースER図](https://user-images.githubusercontent.com/48540482/60796578-9fdab900-a1a8-11e9-93fb-13313633948a.png)

# エラー項目　文字数制限とか
プロフィール profilesテーブル
![プロフィール](https://user-images.githubusercontent.com/48540482/60796605-ad903e80-a1a8-11e9-9ce5-23723af217f3.png)

お届け先住所 delivery_addressesテーブル
![お届け先住所](https://user-images.githubusercontent.com/48540482/60796721-ecbe8f80-a1a8-11e9-8920-ad185063fe6d.png)

メール、パスワード usersテーブル
![メールパスワード](https://user-images.githubusercontent.com/48540482/60796611-aff29880-a1a8-11e9-8264-2fc6bb9535f9.png)

本人確認情報 user_addressesテーブル
![本人確認情報](https://user-images.githubusercontent.com/48540482/60796619-b2ed8900-a1a8-11e9-9c0b-86d9cf9b0af2.png)

商品出品ページ  items item_details shipping_oregins categoriesテーブル
![商品出品１](https://user-images.githubusercontent.com/48540482/60796625-b54fe300-a1a8-11e9-8d33-6beca16646b0.png)
![商品出品２](https://user-images.githubusercontent.com/48540482/60796628-b7b23d00-a1a8-11e9-9beb-8fdfebccdf36.png)



